### PR TITLE
Creation of graphics queue no longer requires a swapchain [closes #67]

### DIFF
--- a/papago-api-client/src/main.cpp
+++ b/papago-api-client/src/main.cpp
@@ -491,7 +491,7 @@ void userTest()
 	auto devices = IDevice::enumerateDevices(*surface, features, extensions);
 	auto& device = devices[0];
 
-	auto swapChain = device->createSwapChain(Format::eR8G8B8A8Unorm, Format::eD32Sfloat, 3, IDevice::PresentMode::eMailbox);
+	auto swapChain = device->createSwapChain(Format::eB8G8R8A8Unorm, Format::eD32Sfloat, 3, IDevice::PresentMode::eMailbox);
 
 	std::vector<CubeVertex> cubeVertices{
 		{ { -0.5f, -0.5f,  0.5f },{ 0.0f, 0.0f } },
@@ -543,9 +543,9 @@ void userTest()
 	auto vertexBuffer = device->createVertexBuffer(cubeVertices);
 	auto indexBuffer = device->createIndexBuffer(cubeIndices);
 
-	auto renderPass = device->createRenderPass(*program, windowWidth, windowHeight, Format::eR8G8B8A8Unorm, Format::eD32Sfloat);
+	auto renderPass = device->createRenderPass(*program, windowWidth, windowHeight, Format::eB8G8R8A8Unorm, Format::eD32Sfloat);
 
-	auto graphicsQueue = device->createGraphicsQueue(*swapChain);
+	auto graphicsQueue = device->createGraphicsQueue();
 
 	std::vector<std::unique_ptr<ISubCommandBuffer>> subCommandBuffers(4);
 	std::vector<std::reference_wrapper<ISubCommandBuffer>> subCommandBufferReferences;
@@ -634,7 +634,7 @@ void userTest()
 			});
 
 			graphicsQueue->submitCommands({ *commandBuffer });
-			graphicsQueue->present();
+			graphicsQueue->present(*swapChain);
 
 			//FPS counter:
 			auto deltaTime = (Clock::now() - lastUpdate);

--- a/papago-api-core/include/idevice.hpp
+++ b/papago-api-core/include/idevice.hpp
@@ -60,7 +60,7 @@ public:
 	virtual void waitIdle() = 0;
 	virtual std::unique_ptr<IDynamicBufferResource> createDynamicUniformBuffer(size_t object_size, int object_count) = 0;
 
-	virtual std::unique_ptr<IGraphicsQueue> createGraphicsQueue(ISwapchain&) = 0;
+	virtual std::unique_ptr<IGraphicsQueue> createGraphicsQueue() = 0;
 
 	struct Features {
 		bool samplerAnisotropy;

--- a/papago-api-core/include/igraphics_queue.hpp
+++ b/papago-api-core/include/igraphics_queue.hpp
@@ -1,14 +1,13 @@
 #pragma once
 class ICommandBuffer;
 class IImageResource;
+class ISwapchain;
 
 class IGraphicsQueue
 {
 public:
 	virtual ~IGraphicsQueue() = default;
 
-	virtual void present() = 0;
+	virtual void present(ISwapchain& swapchain) = 0;
 	virtual void submitCommands(const std::vector<std::reference_wrapper<ICommandBuffer>>&) = 0;
-	virtual IImageResource& getLastRenderedDepthBuffer() = 0;
-	virtual IImageResource& getLastRenderedImage() = 0;
 };

--- a/papago-api-core/src/device.cpp
+++ b/papago-api-core/src/device.cpp
@@ -450,14 +450,14 @@ std::unique_ptr<ISwapchain> Device::createSwapChain(Format colorFormat, Format d
 	return createSwapChain(to_vulkan_format(colorFormat), to_vulkan_format(depthStencilFormat), framebufferCount, vkPreferredPresentMode);
 }
 
-std::unique_ptr<IGraphicsQueue> Device::createGraphicsQueue(ISwapchain& swapChain)
+std::unique_ptr<IGraphicsQueue> Device::createGraphicsQueue()
 {
 	auto queueFamilyIndices = findQueueFamilies(m_vkPhysicalDevice, m_surface);
 	return std::make_unique<GraphicsQueue>(
 		*this, 
 		queueFamilyIndices.graphicsFamily, 
-		queueFamilyIndices.presentFamily, 
-		(SwapChain&)swapChain );
+		queueFamilyIndices.presentFamily 
+	);
 }
 
 std::unique_ptr<ICommandBuffer> Device::createCommandBuffer()

--- a/papago-api-core/src/device.hpp
+++ b/papago-api-core/src/device.hpp
@@ -37,7 +37,7 @@ public:
 	std::unique_ptr<ISubCommandBuffer> createSubCommandBuffer() override;
 	std::unique_ptr<IShaderProgram> createShaderProgram(IVertexShader&, IFragmentShader&) override;
 	std::unique_ptr<IBufferResource> createUniformBuffer(size_t size) override;
-	std::unique_ptr<IGraphicsQueue> createGraphicsQueue(ISwapchain&) override;
+	std::unique_ptr<IGraphicsQueue> createGraphicsQueue() override;
 
 	std::unique_ptr<IDynamicBufferResource> createDynamicUniformBuffer(size_t object_size, int object_count) override;
 

--- a/papago-api-core/src/graphics_queue.cpp
+++ b/papago-api-core/src/graphics_queue.cpp
@@ -11,8 +11,6 @@ void GraphicsQueue::submitCommands(const std::vector<std::reference_wrapper<ICom
 {
 	m_vkGraphicsQueue.waitIdle();
 	std::vector<vk::Semaphore> semaphores = { *m_vkRenderFinishSemaphore};
-	std::vector<vk::Semaphore> waitSemaphores = { *m_vkImageAvailableSemaphore};
-	std::vector<vk::PipelineStageFlags> waitStages = { vk::PipelineStageFlagBits::eColorAttachmentOutput };
 	std::vector<vk::CommandBuffer> vkCommandBuffers;
 	vkCommandBuffers.reserve(commandBuffers.size());
 
@@ -21,16 +19,26 @@ void GraphicsQueue::submitCommands(const std::vector<std::reference_wrapper<ICom
 	}
 
 	vk::SubmitInfo submitInfo = {};
-	submitInfo.setWaitSemaphoreCount(waitSemaphores.size())
-		.setPWaitSemaphores(waitSemaphores.data())
-		.setPWaitDstStageMask(waitStages.data())
-		.setCommandBufferCount(vkCommandBuffers.size())
+	submitInfo.setCommandBufferCount(vkCommandBuffers.size())
 		.setPCommandBuffers(vkCommandBuffers.data())
 		.setSignalSemaphoreCount(semaphores.size())
 		.setPSignalSemaphores(semaphores.data());
 
-	auto& fence = m_swapChain.m_vkFences[m_swapChain.m_currentFramebufferIndex];
-	m_device.m_vkDevice->resetFences({*fence});
+	int fenceIndex = -1;
+	for (auto i = 0; i < m_vkFences.size(); ++i) {
+		if (m_device.m_vkDevice->getFenceStatus(*m_vkFences[i]) == vk::Result::eSuccess) {
+			fenceIndex = i;
+			break;
+		}
+	}
+
+	if (fenceIndex == -1) {
+		fenceIndex = m_vkFences.size();
+		m_vkFences.emplace_back(std::move(m_device.m_vkDevice->createFenceUnique({})));
+	}
+
+	auto& fence = m_vkFences[fenceIndex];
+	m_device.m_vkDevice->resetFences({*fence});	//<-- possible bug: newly created fences might not like to be reset.
 
 	//TODO: Test if this works with several command buffers using the same resources. - Brandborg
 	for (auto& cmd : commandBuffers) {
@@ -40,8 +48,6 @@ void GraphicsQueue::submitCommands(const std::vector<std::reference_wrapper<ICom
 			ITERATE(commandBuffer.m_resourcesInUse),								// .. and this ..
 			std::inserter(m_submittedResources, m_submittedResources.begin()));		// .. into that
 		commandBuffer.m_resourcesInUse.clear();
-
-		
 	}
 
 	for (auto& resource : m_submittedResources) {
@@ -51,23 +57,13 @@ void GraphicsQueue::submitCommands(const std::vector<std::reference_wrapper<ICom
 	m_vkGraphicsQueue.submit(submitInfo, *fence);
 }
 
-IImageResource & GraphicsQueue::getLastRenderedImage()
+void GraphicsQueue::present(ISwapchain& swapchain)
 {
-	return m_swapChain.m_colorResources[m_swapChain.m_currentFramebufferIndex];
-}
-
-IImageResource & GraphicsQueue::getLastRenderedDepthBuffer()
-{
-	auto& colorRes = m_swapChain.m_colorResources;
-	return m_swapChain.m_depthResources[(m_swapChain.m_currentFramebufferIndex + colorRes.size() - 1) % colorRes.size()];
-}
-
-void GraphicsQueue::present()
-{
+	auto& internalSwapChain = dynamic_cast<SwapChain&>(swapchain);
 	m_vkPresentQueue.waitIdle();
 	
 	std::set<ImageResource*> imageResources;
-	imageResources.emplace(&m_swapChain.m_colorResources[m_swapChain.m_currentFramebufferIndex]);
+	imageResources.emplace(&internalSwapChain.m_colorResources[internalSwapChain.m_currentFramebufferIndex]);
 
 	// Find image resources from the submitted resources 
 	for (auto& resource : m_submittedResources) {
@@ -84,14 +80,14 @@ void GraphicsQueue::present()
 	);
 
 	std::vector<vk::Semaphore> semaphores = { *m_vkRenderFinishSemaphore };
-	std::vector<vk::SwapchainKHR> swapchains = { static_cast<vk::SwapchainKHR>(m_swapChain) };
+	std::vector<vk::SwapchainKHR> swapchains = { static_cast<vk::SwapchainKHR>(internalSwapChain) };
 
 	vk::PresentInfoKHR presentInfo = {};
 	presentInfo.setWaitSemaphoreCount(semaphores.size())
 		.setPWaitSemaphores(semaphores.data())
 		.setSwapchainCount(1)
 		.setPSwapchains(swapchains.data())
-		.setPImageIndices(&m_swapChain.m_currentFramebufferIndex);
+		.setPImageIndices(&internalSwapChain.m_currentFramebufferIndex);
 
 	auto res = m_vkPresentQueue.presentKHR(presentInfo);
 
@@ -105,27 +101,31 @@ void GraphicsQueue::present()
 	);
 
 	m_submittedResources.clear();
-
-	auto nextFramebuffer = m_device.m_vkDevice->acquireNextImageKHR(static_cast<vk::SwapchainKHR>(m_swapChain), 0, *m_vkImageAvailableSemaphore, vk::Fence());
-	m_swapChain.m_currentFramebufferIndex = nextFramebuffer.value;
+	//TODO: find some way to not create new fences every present.
+	vk::UniqueFence fence = m_device.m_vkDevice->createFenceUnique({});
+	auto nextFramebuffer = m_device.m_vkDevice->acquireNextImageKHR(static_cast<vk::SwapchainKHR>(internalSwapChain), 0, {}, *fence);
+	auto& oldFence = internalSwapChain.m_vkFences[internalSwapChain.m_currentFramebufferIndex];
+	internalSwapChain.m_currentFramebufferIndex = nextFramebuffer.value;
+	if (m_device.m_vkDevice->getFenceStatus(*oldFence) == vk::Result::eSuccess) {
+		internalSwapChain.m_vkFences[internalSwapChain.m_currentFramebufferIndex] = std::move(fence);
+	}
+	else {
+		PAPAGO_ERROR("DBUG");
+	}
 }
 
-GraphicsQueue::GraphicsQueue(const Device& device, int graphicsQueueIndex, int presentQueueIndex, SwapChain& swapChain)
-	: m_swapChain(swapChain), m_device(device)
+GraphicsQueue::GraphicsQueue(const Device& device, int graphicsQueueIndex, int presentQueueIndex)
+	: m_device(device)
 {
 	m_vkGraphicsQueue = device.m_vkDevice->getQueue(graphicsQueueIndex, 0);
 	m_vkPresentQueue = device.m_vkDevice->getQueue(presentQueueIndex, 0);
 
 	createSemaphores(device.m_vkDevice);
-
-	auto nextFramebuffer = m_device.m_vkDevice->acquireNextImageKHR(static_cast<vk::SwapchainKHR>(m_swapChain), 0, *m_vkImageAvailableSemaphore, vk::Fence());
-	m_swapChain.m_currentFramebufferIndex = nextFramebuffer.value;
 }
 
 void GraphicsQueue::createSemaphores(const vk::UniqueDevice &device)
 {
 	m_vkRenderFinishSemaphore = device->createSemaphoreUnique(vk::SemaphoreCreateInfo());
-	m_vkImageAvailableSemaphore = device->createSemaphoreUnique(vk::SemaphoreCreateInfo());
 }
 
 

--- a/papago-api-core/src/graphics_queue.hpp
+++ b/papago-api-core/src/graphics_queue.hpp
@@ -6,31 +6,28 @@
 
 class Device;
 class CommandBuffer;
-class SwapChain;
+class ISwapChain;
 class ICommandBuffer;
 class ImageResource;
 
 class GraphicsQueue : public IGraphicsQueue
 {
 public:
-	GraphicsQueue(const Device&, int graphicsQueueIndex, int presentQueueIndex, SwapChain&);
+	GraphicsQueue(const Device&, int graphicsQueueIndex, int presentQueueIndex);
 	
-	void present() override;
+	void present(ISwapchain& swapchain) override;
 	void submitCommands(const std::vector<std::reference_wrapper<ICommandBuffer>>&) override;
-	IImageResource& getLastRenderedImage();
-	IImageResource& getLastRenderedDepthBuffer() override;
 private:
 	void createSemaphores(const vk::UniqueDevice&);
 
 	template<vk::ImageLayout from, vk::ImageLayout to>
 	static void transitionImageResources(const CommandBuffer&, const vk::Queue&, std::set<ImageResource*> resources);
 
-	SwapChain& m_swapChain;
 	vk::Queue m_vkGraphicsQueue;
 	vk::Queue m_vkPresentQueue;
 	vk::UniqueSemaphore m_vkRenderFinishSemaphore;
-	vk::UniqueSemaphore m_vkImageAvailableSemaphore;
 	const Device& m_device;
+	std::vector<vk::UniqueFence> m_vkFences;
 
 	std::set<Resource*> m_submittedResources;
 };

--- a/papago-api-core/src/recording_command_buffer.cpp
+++ b/papago-api-core/src/recording_command_buffer.cpp
@@ -32,11 +32,6 @@ T & CommandRecorder<T>::setDynamicIndex(const std::string & uniformName, size_t 
 	m_bindingDynamicOffset[binding] = m_renderPassPtr->m_bindingAlignment[binding] * index;
 
 
-	for (auto& dynamicBindingOffset : m_bindingDynamicOffset)
-	{
-		dynamicBindings.push_back(dynamicBindingOffset.first);
-	}
-
 	std::sort(dynamicBindings.begin(), dynamicBindings.end());
 
 	for (auto b : dynamicBindings) {

--- a/papago-api-core/src/swap_chain.cpp
+++ b/papago-api-core/src/swap_chain.cpp
@@ -55,8 +55,12 @@ SwapChain::SwapChain(
 			.setLayers(1);
 
 		m_vkFramebuffers.emplace_back(device.getVkDevice()->createFramebufferUnique(framebufferCreateInfo));
-		m_vkFences.emplace_back(device.getVkDevice()->createFenceUnique(vk::FenceCreateInfo{}));
+		m_vkFences.emplace_back(device.getVkDevice()->createFenceUnique({}));
 	}
+
+	vk::UniqueFence fence = device.getVkDevice()->createFenceUnique({});
+	m_currentFramebufferIndex = device.getVkDevice()->acquireNextImageKHR(*m_vkSwapChain, 0, {}, *fence).value;
+	m_vkFences[m_currentFramebufferIndex] = std::move(fence);
 }
 
 SwapChain::SwapChain(const Device &device, vk::UniqueSwapchainKHR &swapChain, std::vector<ImageResource>& colorResources, vk::Extent2D extent)
@@ -81,6 +85,7 @@ SwapChain::SwapChain(const Device &device, vk::UniqueSwapchainKHR &swapChain, st
 			.setLayers(1);
 
 		m_vkFramebuffers.emplace_back(device.getVkDevice()->createFramebufferUnique(framebufferCreateInfo));
-		m_vkFences.emplace_back(device.getVkDevice()->createFenceUnique(vk::FenceCreateInfo{}));
 	}
+
+	m_currentFramebufferIndex = device.getVkDevice()->acquireNextImageKHR(*m_vkSwapChain, 0, {}, {}).value;	//<-- possible bug.
 }

--- a/papago-api-core/src/swap_chain.cpp
+++ b/papago-api-core/src/swap_chain.cpp
@@ -39,6 +39,7 @@ SwapChain::SwapChain(
 	// this _may_ be error-prone...
 	m_vkRenderPass = device.createVkRenderpass(m_colorResources[0].m_format, m_depthResources[0].m_format);
 	auto swapChainSize = m_colorResources.size();
+	m_vkFences.resize(swapChainSize);
 
 	for (auto i = 0; i < swapChainSize; ++i) {
 		std::vector<vk::ImageView> attachments = {
@@ -55,9 +56,9 @@ SwapChain::SwapChain(
 			.setLayers(1);
 
 		m_vkFramebuffers.emplace_back(device.getVkDevice()->createFramebufferUnique(framebufferCreateInfo));
-		m_vkFences.emplace_back(device.getVkDevice()->createFenceUnique({}));
 	}
 
+	//ready fences:
 	vk::UniqueFence fence = device.getVkDevice()->createFenceUnique({});
 	m_currentFramebufferIndex = device.getVkDevice()->acquireNextImageKHR(*m_vkSwapChain, 0, {}, *fence).value;
 	m_vkFences[m_currentFramebufferIndex] = std::move(fence);

--- a/papago-api-core/src/swap_chain.hpp
+++ b/papago-api-core/src/swap_chain.hpp
@@ -20,6 +20,7 @@ public:
 	std::vector<vk::UniqueFramebuffer> m_vkFramebuffers;
 	vk::UniqueRenderPass m_vkRenderPass;
 	vk::Extent2D m_vkExtent;
+	//Indicates if image resource is ready to be used. Contains one fence per framebuffer.
 	std::vector<vk::UniqueFence> m_vkFences;
 
 	//updated through GraphicsQueue (both present() and constructor)


### PR DESCRIPTION
- fences for Resources moved from swapchain to graphics queue
- removed getLastRendered[Color|Depth]Image methods from graphics queue (TODO: remake them on swapchain)
- fences to check framebuffer availability added to swapchain (m_vkFences)